### PR TITLE
Mutex deadlock during read timeout fixed

### DIFF
--- a/src/xzero/net/TcpEndPoint.cc
+++ b/src/xzero/net/TcpEndPoint.cc
@@ -115,11 +115,11 @@ bool TcpEndPoint::isOpen() const noexcept {
 
 void TcpEndPoint::close() {
   if (isOpen()) {
+    socket_.close();
+
     if (onEndPointClosed_) {
       onEndPointClosed_(this);
     }
-
-    socket_.close();
   }
 }
 


### PR DESCRIPTION
When TcpEndPoint was closed because of read timeout, TcpConnector::onEndPointClosed() was called repeatedly resulting to mutex deadlock.

Tested with hello_http:
- run hello_http
- open connection with netcat/socat without sending any data
- wait 60 seconds
- hello_http becomes unresponsive
